### PR TITLE
Fix broken wp_trigger_error() call and translate its message

### DIFF
--- a/advanced-multi-block.php
+++ b/advanced-multi-block.php
@@ -21,7 +21,14 @@ if (! defined('ABSPATH') ) {
 if ( file_exists( plugin_dir_path( __FILE__ ) . 'vendor/autoload.php' ) ) {
   require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 } else {
-  wp_trigger_error( 'Advanced Multi Block Plugin: Composer autoload file not found. Please run `composer install`.', E_USER_ERROR );
+  $advanced_multi_block_autoload_error = __( 'Advanced Multi Block Plugin: Composer autoload file not found. Please run `composer install`.', 'advanced-multi-block' );
+
+  if ( function_exists( 'wp_trigger_error' ) ) {
+    wp_trigger_error( __FILE__, $advanced_multi_block_autoload_error, E_USER_ERROR );
+  } else {
+    trigger_error( esc_html( $advanced_multi_block_autoload_error ), E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- fallback for WordPress < 7.0, where wp_trigger_error() does not exist.
+  }
+
   return;
 }
 


### PR DESCRIPTION
## Summary
- Full i18n audit of every PHP string in the plugin: text domain (`advanced-multi-block`) already matches the plugin slug consistently, and every other user-facing string was already correctly wrapped in `esc_html_e()`/`esc_html__()`. This was the one gap.
- `wp_trigger_error()` takes `( $function_name, $message, $error_level = E_USER_NOTICE )` and was only added in WP 7.0. This plugin declares `Requires at least: 6.7` but called it unconditionally with a translatable message string in the `$function_name` slot and `E_USER_ERROR` in the `$message` slot — so on WP 7.0+ it reported a garbled message at the wrong severity, and on WP 6.7–6.9 it fataled with "Call to undefined function wp_trigger_error()".
- Fixed by guarding with `function_exists( 'wp_trigger_error' )` and falling back to plain `trigger_error()` on older core — the same defensive pattern `Register_Blocks.php` already uses for other newer core functions.
- Wrapped the message in `__()` so it's translatable, which it previously was not.

Note: this touches the same `else` block in `advanced-multi-block.php` as the PHPCS PR (#1 in this batch) and the readme/description PR — expect a merge conflict if these are applied out of order; each is otherwise independent.

## Test Plan
- [x] `php -l` passes
- [x] Verified `wp_trigger_error()`'s real signature and `@since 7.0.0` against WordPress core source (`wp-includes/functions.php`)
- [x] Confirmed the `function_exists()` fallback preserves behavior on the plugin's declared minimum (WP 6.7)