### PR TITLE
Update readme.txt for WP 7.1 and replace scaffold placeholder text

### DIFF
--- a/advanced-multi-block.php
+++ b/advanced-multi-block.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:       Advanced Multi Block
- * Description:       Example block scaffolded with Create Block tool.
+ * Description:       Adds Banner, Toggle, and Slider blocks, built with namespaced, Composer-autoloaded PHP.
  * Version:           0.1.0
  * Requires at least: 6.7
  * Requires PHP:      7.4

--- a/readme.txt
+++ b/readme.txt
@@ -1,55 +1,44 @@
 === Advanced Multi Block ===
 Contributors:      The WordPress Contributors
-Tags:              block
-Tested up to:      6.7
+Tags:              block, banner, toggle, slider, interactivity
+Requires at least: 6.7
+Tested up to:      7.1
+Requires PHP:      7.4
 Stable tag:        0.1.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
-Example block scaffolded with Create Block tool.
+Adds Banner, Toggle, and Slider blocks, built with namespaced, Composer-autoloaded PHP.
 
 == Description ==
 
-This is the long description. No limit, and you can use Markdown (as well as in the following sections).
+Advanced Multi Block adds a small set of custom Gutenberg blocks to the block editor:
 
-For backwards compatibility, if this section is missing, the full length of the short description will be used, and
-Markdown parsed.
+* **Banner** – a simple dynamic block that renders a message on the front end.
+* **Toggle** – an interactive block, built with the WordPress Interactivity API, that lets visitors expand or collapse content and switch between a light and dark theme state.
+* **Slider** – a block for presenting content in a slider layout.
+
+The plugin's PHP is organized as namespaced classes (`Advanced_Multi_Block\...`) autoloaded via Composer's PSR-4 autoloader, rather than the classic WordPress `class-*.php` file-naming convention, as a reference implementation of namespaced coding standards in a WordPress plugin.
 
 == Installation ==
 
-This section describes how to install the plugin and get it working.
-
-e.g.
-
 1. Upload the plugin files to the `/wp-content/plugins/advanced-multi-block` directory, or install the plugin through the WordPress plugins screen directly.
-1. Activate the plugin through the 'Plugins' screen in WordPress
-
+1. Run `composer install` in the plugin directory to generate the autoloader (required — the plugin will not activate without it).
+1. Activate the plugin through the 'Plugins' screen in WordPress.
+1. Add the Banner, Toggle, or Slider blocks to any post or page from the block inserter.
 
 == Frequently Asked Questions ==
 
-= A question that someone might have =
+= Why won't the plugin activate? =
 
-An answer to that question.
+The plugin requires its Composer dependencies to be installed first. Run `composer install` in the plugin's directory, then activate it.
 
-= What about foo bar? =
+= Does this plugin require a specific PHP or WordPress version? =
 
-Answer to foo bar dilemma.
-
-== Screenshots ==
-
-1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from
-the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets
-directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png`
-(or jpg, jpeg, gif).
-2. This is the second screen shot
+Yes — PHP 7.4+ and WordPress 6.7+. It has been tested up to WordPress 7.1.
 
 == Changelog ==
 
 = 0.1.0 =
 * Release
 
-== Arbitrary section ==
-
-You may provide arbitrary sections, in the same format as the ones above. This may be of use for extremely complicated
-plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
-"installation." Arbitrary sections will be shown below the built-in sections outlined above.


### PR DESCRIPTION
## Summary
- Bumped `Tested up to: 6.7` → `7.1`.
- Added `Requires at least: 6.7` and `Requires PHP: 7.4` to readme.txt — these were only declared in the plugin file header before, not in readme.txt (WordPress.org reads readme.txt's header for the directory listing, so it should match).
- Replaced the Create Block tool's placeholder Description/Installation/FAQ text in readme.txt with real content describing what the plugin's three blocks (Banner, Toggle, Slider) actually do, including the `composer install` activation requirement.
- Removed the `Screenshots` section (referenced `screenshot-1.png`/`screenshot-2.png`, which don't exist in this repo — Plugin Check flags dangling screenshot references) and the `Arbitrary section` block (contained only the scaffold's explanatory placeholder text, no real content).
- Also updated the plugin file's own header `Description:` field, which had the same `Example block scaffolded with Create Block tool.` placeholder, so it's consistent with readme.txt's short description.
- No version bump — `Stable tag` stays `0.1.0`; Changelog untouched.

Note: this touches the plugin header's `Description:` line in `advanced-multi-block.php`, close to (but not overlapping) the lines changed by the wp_trigger_error PR in this batch — flagging in case of merge-order conflicts.

## Test Plan
- [x] `php -l` passes on advanced-multi-block.php
- [x] Diffed every header field in readme.txt against the plugin file's own header block — `Requires at least`, `Requires PHP`, `Description`, and `Stable tag`/`Version` now match exactly
- [x] Confirmed no remaining references to nonexistent screenshot assets