### PR TITLE
Add index.php stubs to block directory-listing exposure

### DIFF
--- a/Functions/index.php
+++ b/Functions/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Advanced_Multi_Block
+ */

--- a/index.php
+++ b/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Advanced_Multi_Block
+ */

--- a/src/blocks/banner/index.php
+++ b/src/blocks/banner/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Advanced_Multi_Block
+ */

--- a/src/blocks/index.php
+++ b/src/blocks/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Advanced_Multi_Block
+ */

--- a/src/blocks/slider/index.php
+++ b/src/blocks/slider/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Advanced_Multi_Block
+ */

--- a/src/blocks/toggle/index.php
+++ b/src/blocks/toggle/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Advanced_Multi_Block
+ */

--- a/src/index.php
+++ b/src/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package Advanced_Multi_Block
+ */


### PR DESCRIPTION
## Summary
Full security review of the plugin's PHP:
- No superglobal access (`$_GET`/`$_POST`/`$_REQUEST`/`$_SERVER`/`$_COOKIE`/`$_FILES`) anywhere in the codebase.
- No dangerous functions (`eval`, `exec`, `system`, `shell_exec`, `unserialize`, `extract`, `create_function`, `base64_decode`, `assert`) anywhere.
- No `$wpdb` usage or raw SQL — nothing to parameterize.
- All dynamic output already escaped (the two `get_block_wrapper_attributes()`/`wp_interactivity_data_wp_context()` false-positives are documented with `phpcs:ignore` in the PHPCS PR in this batch).
- The one gap: none of the plugin's directories (`.`, `Functions/`, `src/`, `src/blocks/`, and each block folder) had the standard WordPress `index.php` stub, so a server that serves directory listings (`Options +Indexes`, or a misconfigured host) would expose the plugin's file structure. Added the standard stub to all 7 — new files only, no overlap with the other PRs in this batch.

## Test Plan
- [x] `php -l` passes on all 7 new files
- [x] Manually verified each new file is a passive stub with no executable logic — zero behavioral change to the plugin